### PR TITLE
automatic create a github release if merged to master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,11 +32,9 @@ jobs:
 
       - name: create release
         if: github.event_name != 'pull_request' && github.repository == env.MAIN_REPO
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.release_info.outputs.version }}
-          release_name: Release ${{ steps.release_info.outputs.version }}
+          name: Release ${{ steps.release_info.outputs.version }}
           body: ${{ steps.release_info.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+env:
+  MAIN_REPO: IN-CORE/pyincore-data
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: get release info
+        id: release_info
+        run: |
+          version=$(awk -F= '/^release/ { print $2}' docs/source/conf.py | sed "s/[ ']//g")
+          changelog="$(sed -e "1,/^## \[${version}\]/d" -e "/^## \[/,\$d" -e '/^$/d' CHANGELOG.md)"
+          changelog="${changelog//'%'/'%25'}"
+          changelog="${changelog//$'\n'/'%0A'}"
+          changelog="${changelog//$'\r'/'%0D'}"
+          echo "::set-output name=version::$version"
+          echo "::set-output name=changelog::$changelog"
+
+      - name: create release
+        if: github.event_name != 'pull_request' && github.repository == env.MAIN_REPO
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.release_info.outputs.version }}
+          release_name: Release ${{ steps.release_info.outputs.version }}
+          body: ${{ steps.release_info.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
   pull_request:
 


### PR DESCRIPTION
This workflow will use the CHANGELOG to create a github release when code is merged into master, no action from user needed.

in this case if the release in docs/src/config.py is not increased, this will result in a failed build.