### PR TITLE
Fix GitHub action error in posting the container when merged to main

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -6,7 +6,6 @@ on:
       - main
       - develop
       - 'release/*'
-      - test-main
     tags:
       - '*'
 
@@ -15,7 +14,6 @@ on:
       - main
       - develop
       - 'release/*'
-      - test-main
 
 env:
   MAIN_REPO: IN-CORE/pyincore-data
@@ -43,7 +41,7 @@ jobs:
             BRANCH=${GITHUB_REF##*/}
           fi
           echo "GITHUB_BRANCH=${BRANCH}" >> $GITHUB_ENV
-          if [ "$BRANCH" == "test-main" ]; then
+          if [ "$BRANCH" == "main" ]; then
             version=$(awk -F= '/^release/ { print $2}' docs/source/conf.py | sed "s/[ ']//g")
             tags="latest"
             oldversion=""

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - develop
       - 'release/*'
+      - test-main
     tags:
       - '*'
 
@@ -14,6 +15,7 @@ on:
       - main
       - develop
       - 'release/*'
+      - test-main
 
 env:
   MAIN_REPO: IN-CORE/pyincore-data
@@ -41,7 +43,7 @@ jobs:
             BRANCH=${GITHUB_REF##*/}
           fi
           echo "GITHUB_BRANCH=${BRANCH}" >> $GITHUB_ENV
-          if [ "$BRANCH" == "main" ]; then
+          if [ "$BRANCH" == "test-main" ]; then
             version=$(awk -F= '/^release/ { print $2}' docs/source/conf.py | sed "s/[ ']//g")
             tags="latest"
             oldversion=""
@@ -50,6 +52,8 @@ jobs:
               tags="${tags},${version}"
               version=${version%.*}
             done
+            # Remove any unwanted double quotes from tags
+            tags=$(echo $tags | sed 's/"//g')
             echo "VERSION=${version}" >> $GITHUB_ENV
             echo "TAGS=${tags}" >> $GITHUB_ENV
           elif [ "$BRANCH" == "develop" ]; then
@@ -59,6 +63,10 @@ jobs:
             echo "VERSION=testing" >> $GITHUB_ENV
             echo "TAGS=${BRANCH}" >> $GITHUB_ENV
           fi
+
+      # debug TAGS
+      - name: Debug TAGS
+        run: echo "TAGS=${{ env.TAGS }}"
 
       # build image
       - name: Build image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+- Documentation container tagging error by github action [#90](https://github.com/IN-CORE/pyincore/issues/90)
+
 ## [0.7.0] - 2024-10-23
 
 ### Added


### PR DESCRIPTION
There is an error in posting the documentation docker image by github action when the branch gets merged to the main branch. The PR fixes the problem but it is not easy to test unless this PR gets merged to main. I have tested this branch by creating the branch named "test-main" and made github action to response to the test-main branch instead of main branch. Then, it worked successfully and posted the docker container with the correct versioning. If you check the [hub.ncsa.illinois.edu](https://hub.ncsa.illinois.edu/harbor/projects/5/repositories/doc%2Fpyincore-data/artifacts-tab) and see the tag with 0, 0.7, 0.7.0, and latest, that is the result from this PR